### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is an example project using [NixOS](https://nixos.org/) to declaratively configure a VM with multiple services that can run on a free tier micro instance (see [howto](howto.md) for details).
 
-The configuration is mostly not specific to the cloud service and can be adapted to other providers (e.g. [Amazon EC2](https://nixos.wiki/wiki/Install_NixOS_on_Amazon_EC2)).
+The configuration is mostly not specific to the cloud service and can be adapted to other providers (e.g. [Amazon EC2](https://wiki.nixos.org/wiki/Install_NixOS_on_Amazon_EC2)).
 
 ## Services overview
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️